### PR TITLE
Update deno.yml with App Check site key script

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -47,12 +47,21 @@ jobs:
         env:
           FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
         run: |
-          mkdir secrets;
+          mkdir -p secrets;
           cat << EOF > ./secrets/firebase-config.ts
           import { FirebaseOptions } from 'firebase/app';
           export const firebaseConfig: FirebaseOptions = {
              $(echo "$FIREBASE_CONFIG")
           };
+          EOF
+
+      - name: set APP_CHECK_SITE_KEY from GitHub secret
+        env:
+          APP_CHECK_SITE_KEY: ${{ secrets.APP_CHECK_SITE_KEY }}
+        run: |
+          mkdir -p secrets;
+          cat << EOF > ./secrets/app-check-config.ts
+          export const appCheckSiteKey = $(echo "$APP_CHECK_SITE_KEY");
           EOF
 
       - name: Setup Deno

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           mkdir -p secrets;
           cat << EOF > ./secrets/app-check-config.ts
-          export const appCheckSiteKey = $(echo "$APP_CHECK_SITE_KEY");
+          export const appCheckSiteKey = $(echo "\"$APP_CHECK_SITE_KEY\"");
           EOF
 
       - name: Setup Deno


### PR DESCRIPTION
To enable GitHub workflow runners to create secrets during CI/CD jobs, I've added a new step to create the app check script with a GitHub secret storing the App Check site key.