### PR TITLE
Cleaned up and corrected App Check loader and workflow environment variables.

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -6,10 +6,19 @@
 # This workflow will install Deno then run `deno lint` and `deno test`.
 # For more information see: https://github.com/denoland/setup-deno
 
+# Workflow Notes
+# 1. Workflow defines a single job named `test`
+# 2. Uses a custom environment named `workflow` running on `ubuntu-latest`
+# 3. Sets environment variables for debug tests on GitHub runners / App Check debug token
+# 4. Runs linting with Deno first to stop if there are any detectable code quality issues
+# 5. Runs `npm ci` for a clean install of node dependencies using the `workflow` Angular configuration
+# 6. Builds the Angular project in test job working directory
+# 7. This workflow file does _not_ deploy the project. That's handled under deployments.
+
 name: Lint App with Deno / Build and test Angular App with Angular ng test/karma
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
     branches: ["main"]
   pull_request:
@@ -21,12 +30,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: workflow
-      url: https://github.com
+      url: https://console.firebase.google.com/
     env:
       ON_GITHUB_RUNNER: true
-      APP_CHECK_DEBUG_TOKEN_FROM_CI: ${{ secrets.APP_CHECK_DEBUG_TOKEN_FROM_CI }}
+      FIREBASE_APPCHECK_DEBUG_TOKEN: ${{ secrets.FIREBASE_APPCHECK_DEBUG_TOKEN_FOR_CI }}
 
     defaults:
       run:
@@ -34,15 +43,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['22.x']
+        node-version: ["22.x"]
 
-    steps: 
+    steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: "npm"
 
       - name: set FIREBASE_CONFIG from GitHub secret
         env:
@@ -69,7 +78,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-          
+
       # Uncomment this step to verify the use of 'deno fmt' on each commit.
       # - name: Verify formatting
       #   run: deno fmt --check
@@ -81,8 +90,7 @@ jobs:
         run: npm ci -c workflow
 
       - name: build the Angular project with npm
-        # run if a script in package.json is present
-        run: npm run workflow-build --if-present
+        run: npm run workflow-build
 
       - name: test Angular project
         run: npm run workflow-test

--- a/my-resume-app/src/app/app.component.ts
+++ b/my-resume-app/src/app/app.component.ts
@@ -4,17 +4,30 @@ import { MatIconModule } from '@angular/material/icon';
 import { Firestore, getFirestore } from 'firebase/firestore';
 
 import { initializeApp } from 'firebase/app';
-import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
 
 import { ExperiencesComponent } from './experiences/experiences.component';
 import { FirebaseAppService } from './services/firebase-app.service';
 import { SvgIconService } from './services/svg-icon.service';
 import { firebaseConfig } from '../../secrets/firebase-config';
-import { appCheckSiteKey } from '../../secrets/app-check-config';
 import { environment } from '../environments/environment';
 import { setupEmulator } from './services/helpers/setupEmulator';
+import { setupAppCheck } from './setupAppCheck';
 
-const app = initializeApp(firebaseConfig);
+/**
+ * Object literal type alias containing data about a special reserved environment variable for App Check.
+ * @var name The name of the debug token environment variable from documentation.
+ * @var host The online documentation host server FQDN.
+ * @var filename The document from the documentation server.
+ * @var version (as of 2024-11-12) A publishing tag containing a date, revision, and release candidate number
+ */
+export const AppCheckDebugToken = {
+  name: 'FIREBASE_APPCHECK_DEBUG_TOKEN',
+  host: 'firebase.google.com',
+  filename: '/docs/app-check/web/debug-provider',
+  version: 't-devsite-webserver-20241112-r02-rc01.464830024708363737',
+};
+
+export const app = initializeApp(firebaseConfig);
 
 setupAppCheck();
 
@@ -29,7 +42,7 @@ if (environment.useFirebaseEmulator) {
   standalone: true,
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
-  imports: [MatToolbarModule, MatIconModule, ExperiencesComponent]
+  imports: [MatToolbarModule, MatIconModule, ExperiencesComponent],
 })
 export class AppComponent implements OnInit {
   title = 'my-resume-app';
@@ -42,69 +55,6 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     this.firebaseAppService.getGitHubLink().subscribe((webLink) => {
       this.gitHubUrl = webLink.url;
-    });
-  }
-}
-
-function setupAppCheck() {
-  if (!environment.useAppCheck && environment.production) {
-    console.warn(
-      `Firebase App "${app.name}": App Check has been disabled. Please turn it back on.`
-    );
-  }
-
-  // Use debug tokens for App Check in debug builds for localhost and CI
-  if (environment.useAppCheck) {
-    // when true, debug token env configuration will emit a debug token in the JavaScript console
-    // which can then be set up in Firebase - App Check console
-    let appCheckDebugToken: boolean | string =
-      environment.useAppCheckDebugToken;
-
-    // CI environments require generated token from Firebase - App Check console
-    if (environment.useCIAppCheckDebugToken) {
-      // load App Check CI debug token from the CI Node.js environment's global variables
-      if (Object.keys(globalThis).includes('APP_CHECK_DEBUG_TOKEN_FROM_CI')) {
-        const appCheckDebugTokenFromCI = Object.values(globalThis).find(
-          (gb) => gb === 'APP_CHECK_DEBUG_TOKEN_FROM_CI'
-        );
-
-        // App Check debug token should be a GUID, but just check that it isn't the empty string
-        if (
-          typeof appCheckDebugTokenFromCI === 'string' &&
-          appCheckDebugTokenFromCI.length === 0
-        ) {
-          appCheckDebugToken = Object.values(globalThis).find(
-            (gb) => gb === 'APP_CHECK_DEBUG_TOKEN_FROM_CI'
-          );
-          console.info(
-            'The App Check debug token was loaded from the CI environment.'
-          );
-        } else {
-          console.error(
-            'The debug token could not be loaded from the CI environment.'
-          );
-        }
-      }
-    }
-
-    // The globalThis global property allows one to access the global object regardless of the current environment.
-    Object.defineProperty(globalThis, 'FIREBASE_APPCHECK_DEBUG_TOKEN', {
-      value: appCheckDebugToken,
-      enumerable: false,
-      configurable: true,
-      writable: true,
-    });
-  }
-
-  if (environment.useAppCheck) {
-    // Pass your reCAPTCHA v3 site key (public key) to activate(). Make sure this
-    // key is the counterpart to the secret key you set in the Firebase console.
-    initializeAppCheck(app, {
-      provider: new ReCaptchaV3Provider(appCheckSiteKey),
-
-      // Optional argument. If true, the SDK automatically refreshes App Check
-      // tokens as needed.
-      isTokenAutoRefreshEnabled: true,
     });
   }
 }

--- a/my-resume-app/src/app/setupAppCheck.ts
+++ b/my-resume-app/src/app/setupAppCheck.ts
@@ -1,0 +1,102 @@
+import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
+import { appCheckSiteKey } from '../../secrets/app-check-config';
+import { environment } from '../environments/environment';
+import { AppCheckDebugToken, app } from './app.component';
+
+export function setupAppCheck() {
+  // Use debug tokens for App Check in debug builds for localhost and CI
+  if (environment.useAppCheckDebugToken) {
+    // when true, debug token env configuration will emit a debug token in the JavaScript console
+    // which can then be set up in Firebase - App Check console
+    // CI environments require generated token from Firebase - App Check console in the same environment variable
+    // The globalThis global property allows one to access the global object regardless of the current environment.
+    Object.defineProperty(globalThis, AppCheckDebugToken.name, {
+      value: environment.useAppCheckDebugToken,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+
+    // Reload to local scope and report if environment variables are loaded in Node.js environment
+    const localAppCheckState = loadAppCheckEnv();
+
+    if (localAppCheckState.appCheckDebugGlobalState === false) {
+      console.error(
+        `App Check debug token could not be loaded into global object during function ${setupAppCheck.name}`
+      );
+    }
+
+    if (localAppCheckState.appCheckDebugGlobalState !== false) {
+      console.info(
+        `App Check debug token was succesfully loaded into globalThis.${AppCheckDebugToken.name} during function ${setupAppCheck.name}()`
+      );
+    }
+  }
+
+  appCheckDebugTokenFailSafe();
+
+  if (environment.useAppCheck || environment.production) {
+    // Pass your reCAPTCHA v3 site key (public key) to activate(). Make sure this
+    // key is the counterpart to the secret key you set in the Firebase console.
+    initializeAppCheck(app, {
+      provider: new ReCaptchaV3Provider(appCheckSiteKey),
+
+      // Optional argument. If true, the SDK automatically refreshes App Check
+      // tokens as needed.
+      isTokenAutoRefreshEnabled: true,
+    });
+  }
+
+  const localAppCheckState = loadAppCheckEnv();
+
+  if (
+    environment.production === false &&
+    localAppCheckState.appCheckDebugGlobalState === false
+  ) {
+    console.error(
+      `Firebase App Check debug token ${AppCheckDebugToken.name} is set to ${localAppCheckState.appCheckDebugGlobalState} and production = ${environment.production}.`
+    );
+  }
+}
+
+function loadAppCheckEnv(): {
+  appCheckDebugGlobalIndex: number;
+  appCheckDebugGlobalState: boolean | string;
+} {
+  return {
+    appCheckDebugGlobalIndex: Object.keys(globalThis).indexOf(
+      AppCheckDebugToken.name
+    ),
+    appCheckDebugGlobalState: Object.values(globalThis).at(
+      Object.keys(globalThis).indexOf(AppCheckDebugToken.name)
+    ),
+  };
+}
+
+/**
+ * Production Environment Fail-safe settings
+ * @summary
+ * 1. enables App Check environment
+ *  While disabled, App Check does not protect the application from abusive traffic and unverified parties.
+ *  While enabled, App Check uses recaptcha to provide access to Firebase resources from verified apps.
+ * 2. disables App Check debug token
+ *  While enabled, the App Check debug token indicates that the application allows access to your Firebase resources from unverified devices.
+ *  While disabled, App Check will not use a debug token and instead will be authorized by App Check. Enforcement will deny any unverified inbound sessions.
+ */
+function appCheckDebugTokenFailSafe() {
+  if (environment.production) {
+    Object.defineProperty(globalThis, AppCheckDebugToken.name, {
+      value: false,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  // also display an error to catch the attention of anyone looking in the browser Console log.
+  if (!environment.useAppCheck && environment.production) {
+    console.error(
+      `Firebase App "${app.name}": App Check has been disabled. Please turn it back on.`
+    );
+  }
+}

--- a/my-resume-app/src/environments/environment.development.ts
+++ b/my-resume-app/src/environments/environment.development.ts
@@ -3,5 +3,4 @@ export const environment = {
   useFirebaseEmulator: true,
   useAppCheck: false,
   useAppCheckDebugToken: false,
-  useCIAppCheckDebugToken: false,
 };

--- a/my-resume-app/src/environments/environment.ts
+++ b/my-resume-app/src/environments/environment.ts
@@ -3,5 +3,4 @@ export const environment = {
   useFirebaseEmulator: false,
   useAppCheck: true,
   useAppCheckDebugToken: false,
-  useCIAppCheckDebugToken: false,
 };

--- a/my-resume-app/src/environments/environment.workflow.ts
+++ b/my-resume-app/src/environments/environment.workflow.ts
@@ -3,5 +3,4 @@ export const environment = {
   useFirebaseEmulator: false,
   useAppCheck: true,
   useAppCheckDebugToken: true,
-  useCIAppCheckDebugToken: true
 }


### PR DESCRIPTION
For this PR, I'm attempting to set the environment variable during workflow and I've removed the special handling and separate Angular environment member environment.useCIAppCheckDebugToken. If environment.useAppCheckDebugToken is set to true before compilation, then the JavaScript runtime should have access to this environment variable through the global object accessor globalThis.

Broke down long function setupAppCheck() and setup fail-safe for production mode in appCheckDebugTokenFailSafe.
